### PR TITLE
Fix build errors and expand structural equation types

### DIFF
--- a/src/components/learning/CrossDeviceSyncManager.vue
+++ b/src/components/learning/CrossDeviceSyncManager.vue
@@ -237,8 +237,8 @@ interface SyncConflict {
   id: string
   moduleName: string
   description: string
-  localData: any
-  remoteData: any
+  localData: unknown
+  remoteData: unknown
   timestamp: Date
 }
 
@@ -296,9 +296,9 @@ const syncStatusText = computed(() => {
 
 // 获取设备图标
 const getDeviceIcon = (deviceType: string) => {
-  const icons = {
+  const icons: Record<string, string> = {
     mobile: 'PhoneIcon',
-    tablet: 'TabletIcon', 
+    tablet: 'TabletIcon',
     desktop: 'ComputerDesktopIcon'
   }
   return icons[deviceType] || 'DevicePhoneMobileIcon'
@@ -436,18 +436,6 @@ const loadStats = () => {
   }
 }
 
-// 更新统计数据
-const updateStats = (success: boolean, dataSize: number = 0) => {
-  stats.value.totalSyncs++
-  if (success) {
-    stats.value.successfulSyncs++
-    stats.value.dataSynced += dataSize
-  } else {
-    stats.value.failedSyncs++
-  }
-  
-  localStorage.setItem(`sync_stats_${props.userId}`, JSON.stringify(stats.value))
-}
 
 // 检测连接的设备
 const detectConnectedDevices = () => {

--- a/src/components/paper-reproduction/PaperReproductionView.vue
+++ b/src/components/paper-reproduction/PaperReproductionView.vue
@@ -182,7 +182,7 @@
         <h2>Research Model</h2>
         <div class="model-container">
           <div class="research-model">
-            <img src="/research-model.png" alt="Research Model" class="model-diagram">
+            <img src="/TAT理论的结构方程.png" alt="Research Model" class="model-diagram" />
             <p class="model-caption">Figure 1. Research Model</p>
           </div>
           
@@ -446,14 +446,14 @@
         <div class="model-fit-section">
           <h3>Model Fit Statistics</h3>
           <div class="fit-stats-grid">
-            <div class="fit-card">
-              <h4>Reliability</h4>
-              <ul>
-                <li>Cronbach's α: {{ modelFit.cronbachAlpha.extroversion }}</li>
-                <li>Composite Reliability: {{ modelFit.compositeReliability.extroversion }}</li>
-                <li>AVE: {{ modelFit.averageVarianceExtracted.extroversion }}</li>
-              </ul>
-            </div>
+              <div class="fit-card">
+                <h4>Reliability</h4>
+                <ul>
+                  <li>Cronbach's α: {{ measurementModel.extroversion.cronbachAlpha }}</li>
+                  <li>Composite Reliability: {{ measurementModel.extroversion.compositeReliability }}</li>
+                  <li>AVE: {{ measurementModel.extroversion.averageVarianceExtracted }}</li>
+                </ul>
+              </div>
 
             <div class="fit-card">
               <h4>Explained Variance (R²)</h4>
@@ -466,16 +466,16 @@
               </ul>
             </div>
 
-            <div class="fit-card">
-              <h4>Effect Size (f²)</h4>
-              <ul>
-                <li>Tangibles: {{ modelFit.fSquared.tangibles }} (small)</li>
-                <li>Reliability: {{ modelFit.fSquared.reliability }} (none)</li>
-                <li>Responsiveness: {{ modelFit.fSquared.responsiveness }} (very small)</li>
-                <li>Assurance: {{ modelFit.fSquared.assurance }} (very small)</li>
-                <li>Empathy: {{ modelFit.fSquared.empathy }} (very small)</li>
-              </ul>
-            </div>
+              <div class="fit-card">
+                <h4>Effect Size (f²)</h4>
+                <ul>
+                  <li>Tangibles: {{ modelFit.effectSize.tangibles }} (small)</li>
+                  <li>Reliability: {{ modelFit.effectSize.reliability }} (none)</li>
+                  <li>Responsiveness: {{ modelFit.effectSize.responsiveness }} (very small)</li>
+                  <li>Assurance: {{ modelFit.effectSize.assurance }} (very small)</li>
+                  <li>Empathy: {{ modelFit.effectSize.empathy }} (very small)</li>
+                </ul>
+              </div>
           </div>
         </div>
       </section>
@@ -575,7 +575,7 @@
                 <span class="finding-icon">✓</span>
                 <strong>H1 Supported: Tangibles Dimension</strong>
               </div>
-              <p>Introverts attach significantly more value to tangibles (β = -0.215, p < 0.01). This supports TAT theory as introverts are more sensitive to environmental stimuli and physical surroundings.</p>
+                <p>Introverts attach significantly more value to tangibles (β = -0.215, p &lt; 0.01). This supports TAT theory as introverts are more sensitive to environmental stimuli and physical surroundings.</p>
             </div>
 
             <div class="finding-item not-supported">
@@ -591,12 +591,105 @@
                 <span class="finding-icon">✓</span>
                 <strong>H5 Supported: Empathy Dimension</strong>
               </div>
-              <p>Extroverts attach significantly more value to empathy (β = 0.109, p < 0.05). This aligns with extroverts' preference for social interaction and personalized attention.</p>
+                <p>Extroverts attach significantly more value to empathy (β = 0.109, p &lt; 0.05). This aligns with extroverts' preference for social interaction and personalized attention.</p>
             </div>
           </div>
         </div>
 
-        <!-- Advanced Statistical Analysis -->\n        <div class=\"analysis-section\">\n          <h3>Advanced Statistical Metrics</h3>\n          <div class=\"stats-grid\">\n            <div class=\"stat-card\">\n              <h4>Effect Sizes (Cohen's d)</h4>\n              <ul>\n                <li><strong>Tangibles:</strong> d = {{ calculateEffectSize(servqualComparison.tangibles.introverts, servqualComparison.tangibles.extroverts).toFixed(3) }} ({{ getEffectSizeLabel(calculateEffectSize(servqualComparison.tangibles.introverts, servqualComparison.tangibles.extroverts)) }})</li>\n                <li><strong>Empathy:</strong> d = {{ calculateEffectSize(servqualComparison.empathy.extroverts, servqualComparison.empathy.introverts).toFixed(3) }} ({{ getEffectSizeLabel(calculateEffectSize(servqualComparison.empathy.extroverts, servqualComparison.empathy.introverts)) }})</li>\n                <li><strong>Reliability:</strong> d = {{ calculateEffectSize(servqualComparison.reliability.introverts, servqualComparison.reliability.extroverts).toFixed(3) }} ({{ getEffectSizeLabel(calculateEffectSize(servqualComparison.reliability.introverts, servqualComparison.reliability.extroverts)) }})</li>\n              </ul>\n            </div>\n\n            <div class=\"stat-card\">\n              <h4>Statistical Power Analysis</h4>\n              <ul>\n                <li><strong>Sample Size:</strong> N = {{ descriptiveStats.sampleSize }}</li>\n                <li><strong>Power (1-β):</strong> 0.80 (adequate)</li>\n                <li><strong>Alpha Level:</strong> α = 0.05</li>\n                <li><strong>Minimum Detectable Effect:</strong> d = 0.25</li>\n              </ul>\n            </div>\n\n            <div class=\"stat-card\">\n              <h4>Model Validation Metrics</h4>\n              <ul>\n                <li><strong>Bootstraps:</strong> 5,000 samples</li>\n                <li><strong>Path Significance:</strong> 2/5 hypotheses supported</li>\n                <li><strong>Total Variance Explained:</strong> {{ ((modelFit.rSquared.tangibles + modelFit.rSquared.empathy) * 100 / 2).toFixed(1) }}%</li>\n                <li><strong>Predictive Relevance:</strong> Q² > 0 for significant paths</li>\n              </ul>\n            </div>\n          </div>\n        </div>
+        <!-- Advanced Statistical Analysis -->
+        <div class="analysis-section">
+          <h3>Advanced Statistical Metrics</h3>
+          <div class="stats-grid">
+            <div class="stat-card">
+              <h4>Effect Sizes (Cohen's d)</h4>
+              <ul>
+                <li>
+                  <strong>Tangibles:</strong>
+                  d =
+                  {{
+                    calculateEffectSize(
+                      servqualComparison.tangibles.introverts,
+                      servqualComparison.tangibles.extroverts
+                    ).toFixed(3)
+                  }}
+                  (
+                  {{
+                    getEffectSizeLabel(
+                      calculateEffectSize(
+                        servqualComparison.tangibles.introverts,
+                        servqualComparison.tangibles.extroverts
+                      )
+                    )
+                  }}
+                  )
+                </li>
+                <li>
+                  <strong>Empathy:</strong>
+                  d =
+                  {{
+                    calculateEffectSize(
+                      servqualComparison.empathy.extroverts,
+                      servqualComparison.empathy.introverts
+                    ).toFixed(3)
+                  }}
+                  (
+                  {{
+                    getEffectSizeLabel(
+                      calculateEffectSize(
+                        servqualComparison.empathy.extroverts,
+                        servqualComparison.empathy.introverts
+                      )
+                    )
+                  }}
+                  )
+                </li>
+                <li>
+                  <strong>Reliability:</strong>
+                  d =
+                  {{
+                    calculateEffectSize(
+                      servqualComparison.reliability.introverts,
+                      servqualComparison.reliability.extroverts
+                    ).toFixed(3)
+                  }}
+                  (
+                  {{
+                    getEffectSizeLabel(
+                      calculateEffectSize(
+                        servqualComparison.reliability.introverts,
+                        servqualComparison.reliability.extroverts
+                      )
+                    )
+                  }}
+                  )
+                </li>
+              </ul>
+            </div>
+
+            <div class="stat-card">
+              <h4>Statistical Power Analysis</h4>
+              <ul>
+                <li><strong>Sample Size:</strong> N = {{ descriptiveStats.sampleSize }}</li>
+                <li><strong>Power (1-β):</strong> 0.80 (adequate)</li>
+                <li><strong>Alpha Level:</strong> α = 0.05</li>
+                <li><strong>Minimum Detectable Effect:</strong> d = 0.25</li>
+              </ul>
+            </div>
+
+            <div class="stat-card">
+              <h4>Model Validation Metrics</h4>
+              <ul>
+                <li><strong>Bootstraps:</strong> 5,000 samples</li>
+                <li><strong>Path Significance:</strong> 2/5 hypotheses supported</li>
+                <li>
+                  <strong>Total Variance Explained:</strong>
+                  {{ ((modelFit.rSquared.tangibles + modelFit.rSquared.empathy) * 100 / 2).toFixed(1) }}%
+                </li>
+                <li><strong>Predictive Relevance:</strong> Q² > 0 for significant paths</li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
   </div>
@@ -610,7 +703,6 @@ import { descriptiveStatistics, paperResults, simulatedData } from '@/data/simul
 
 // Reactive data
 const activeSection = ref('abstract')
-const comparisonChart = ref<HTMLCanvasElement>()
 
 const sections = [
   { id: 'abstract', title: '摘要 Abstract' },
@@ -653,6 +745,7 @@ const servqualDimensions = [
 const modelResults = paperResults.hypothesisResults
 
 const modelFit = paperResults.structuralModel
+const measurementModel = paperResults.measurementModel
 
 const descriptiveStats = descriptiveStatistics
 
@@ -704,12 +797,6 @@ const getDifferenceClass = (difference: number) => {
   return 'small-difference'
 }
 
-// Add statistical significance indicators
-const getSignificanceIndicator = (difference: number) => {
-  if (Math.abs(difference) > 5) return '***'
-  if (Math.abs(difference) > 2) return '*'
-  return 'n.s.'
-}
 
 // Calculate effect sizes
 const calculateEffectSize = (mean1: number, mean2: number, pooledSD: number = 5.2) => {

--- a/src/components/structural-equation/StructuralEquationVisualization.vue
+++ b/src/components/structural-equation/StructuralEquationVisualization.vue
@@ -66,11 +66,11 @@
             </div>
           </div>
         </div>
-        <div class="info-section">
+        <div class="info-section" v-if="model.originalImage">
           <h4>原始图片信息</h4>
-          <p><strong>文件名:</strong> {{ model.originalImage.filename }}</p>
-          <p><strong>来源:</strong> {{ model.originalImage.source }}</p>
-          <p><strong>分析日期:</strong> {{ model.originalImage.analysisDate }}</p>
+          <p><strong>文件名:</strong> {{ model.originalImage?.filename }}</p>
+          <p><strong>来源:</strong> {{ model.originalImage?.source }}</p>
+          <p><strong>分析日期:</strong> {{ model.originalImage?.analysisDate }}</p>
         </div>
       </div>
     </div>

--- a/src/components/ui/AdaptiveButton.vue
+++ b/src/components/ui/AdaptiveButton.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, type Component } from 'vue'
+import { ref, computed, type Component, useSlots } from 'vue'
 import { useResponsive } from '@/composables/useResponsive'
 import { usePerformanceOptimization } from '@/composables/usePerformanceOptimization'
 
@@ -78,6 +78,7 @@ const { deviceInfo, isMobile } = useResponsive()
 const { performanceConfig } = usePerformanceOptimization()
 
 const showTouchFeedback = ref(false)
+const slots = useSlots()
 const touchFeedbackStyle = ref({})
 
 // 自适应尺寸
@@ -109,7 +110,7 @@ const buttonClasses = computed(() => [
     'button-disabled': props.disabled,
     'button-touch-optimized': props.touchOptimized && deviceInfo.value.touchSupport,
     'button-with-icon': props.icon,
-    'button-icon-only': props.icon && !props.$slots.default,
+    'button-icon-only': props.icon && !slots.default,
     'button-reduced-motion': !performanceConfig.value.enableAnimations
   }
 ])

--- a/src/types/structural-equation.ts
+++ b/src/types/structural-equation.ts
@@ -4,7 +4,17 @@
 export interface StructuralEquationNode {
   id: string
   label: string
-  type: 'context-group' | 'situational-cue' | 'core-construct' | 'mediator' | 'outcome' | 'final-outcome' | 'outcome-group' | 'motivation'
+  type:
+    | 'context-group'
+    | 'situational-cue'
+    | 'core-construct'
+    | 'mediator'
+    | 'outcome'
+    | 'final-outcome'
+    | 'outcome-group'
+    | 'motivation'
+    | 'independent-variable'
+    | 'dependent-variable'
   description: string
   examples: string[]
   position: { x: number; y: number }
@@ -16,6 +26,7 @@ export interface StructuralEquationNode {
   relatedConcepts: string[]
   version: string
   lastUpdated: Date
+  measurementItems?: string[]
 }
 
 export interface StructuralEquationRelationship {
@@ -25,10 +36,21 @@ export interface StructuralEquationRelationship {
   label: string
   description: string
   strength: number
-  type: 'activation' | 'direct-effect' | 'mediation' | 'moderation' | 'feedback'
+  type:
+    | 'activation'
+    | 'direct-effect'
+    | 'mediation'
+    | 'moderation'
+    | 'feedback'
+    | 'positive-effect'
+    | 'negative-effect'
+    | 'marginal-effect'
+    | 'non-significant'
   researchEvidence: ResearchEvidence[]
   pathCoefficient?: number
-  significance?: 'p<0.001' | 'p<0.01' | 'p<0.05' | 'ns'
+  significance?: 'p<0.001' | 'p<0.01' | 'p<0.05' | 'ns' | string
+  tStatistic?: number
+  standardError?: number
   version: string
   lastUpdated: Date
 }
@@ -44,6 +66,7 @@ export interface ResearchEvidence {
   effectSize?: number
   reliability: number
   validity: 'high' | 'medium' | 'low'
+  cronbachAlpha?: number
 }
 
 export interface CaseStudy {
@@ -67,7 +90,7 @@ export interface StructuralEquationModel {
   lastUpdated: Date
   nodes: Record<string, StructuralEquationNode>
   relationships: StructuralEquationRelationship[]
-  originalImage: {
+  originalImage?: {
     filename: string
     description: string
     source: string
@@ -75,11 +98,47 @@ export interface StructuralEquationModel {
   }
   validationResults: ValidationResult[]
   changeHistory: ChangeHistoryEntry[]
+  modelFitStatistics?: {
+    cronbachAlpha: Record<string, number>
+    compositeReliability: Record<string, number>
+    averageVarianceExtracted: Record<string, number>
+    rSquared: Record<string, number>
+    fSquared: Record<string, number>
+    qSquared: Record<string, number>
+  }
+  originalStudy?: {
+    title: string
+    authors: string
+    year: number
+    journal: string
+    doi: string
+    sampleSize: number
+    methodology: string
+    participants: string
+    setting: string
+  }
+  theoreticalFoundation?: {
+    mainTheory: string
+    supportingTheories: string[]
+    keyPrinciples: string[]
+  }
+  researchHypotheses?: {
+    id: string
+    hypothesis: string
+    result: string
+    interpretation: string
+  }[]
 }
 
 export interface ValidationResult {
   id: string
-  validationType: 'structural' | 'theoretical' | 'empirical'
+  validationType:
+    | 'structural'
+    | 'theoretical'
+    | 'empirical'
+    | 'measurement-model'
+    | 'structural-model'
+    | 'discriminant-validity'
   status: 'valid' | 'warning' | 'error'
   message: string
   timestamp: Date
@@ -89,9 +148,16 @@ export interface ValidationResult {
 export interface ChangeHistoryEntry {
   id: string
   timestamp: Date
-  changeType: 'node-added' | 'node-modified' | 'node-removed' | 'relationship-added' | 'relationship-modified' | 'relationship-removed'
+  changeType:
+    | 'node-added'
+    | 'node-modified'
+    | 'node-removed'
+    | 'relationship-added'
+    | 'relationship-modified'
+    | 'relationship-removed'
+    | 'model-creation'
   elementId: string
-  changes: Record<string, { old: any; new: any }>
+  changes: Record<string, { old: unknown; new: unknown }>
   author: string
   reason: string
 }

--- a/src/views/DocumentViewerView.vue
+++ b/src/views/DocumentViewerView.vue
@@ -156,6 +156,7 @@ mermaid.initialize({
   gantt: {
     titleTopMargin: 25,
     barHeight: 20,
+    // @ts-expect-error - fontFamily is not defined in Mermaid's Gantt config types
     fontFamily: '"Inter", "Noto Sans SC", system-ui, sans-serif',
     fontSize: 11,
     gridLineStartPadding: 35,


### PR DESCRIPTION
## Summary
- Replace invalid statistical section in paper reproduction view and correct research model image path
- Broaden structural-equation type unions and optional fields to support new model data
- Improve type safety in cross-device sync manager and document viewer configuration

## Testing
- `npm run test:unit`
- `npm run build`
- `npm run lint` *(fails: Unexpected any, unused vars, and require() import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893491ce1708322ace62ba95b6613f3